### PR TITLE
Add Redux to manage state

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "react-dom": "^15.4.1",
     "react-redux": "^4.4.6",
     "react-router": "^3.0.0",
+    "react-router-redux": "^4.0.7",
     "reactstrap": "^3.9.1",
     "redux": "^3.6.0",
+    "redux-devtools-extension": "^1.0.0",
     "redux-observable": "^0.12.2",
     "rxjs": "^5.0.0-rc.4"
   },

--- a/src/app/ConnectedApp.js
+++ b/src/app/ConnectedApp.js
@@ -1,0 +1,22 @@
+import { Provider } from 'react-redux';
+import { Router, browserHistory } from 'react-router';
+import { syncHistoryWithStore } from 'react-router-redux'
+import React from 'react';
+
+import createRoutes from './routes';
+import createStore from './create-store';
+
+const store = createStore();
+const routes = createRoutes(store);
+const history = syncHistoryWithStore(browserHistory, store);
+
+/**
+ * Represents the application when hooked up to state and routes
+ */
+export default function ConnectedApp() {
+  return (
+    <Provider store={store}>
+      <Router routes={routes} history={history} />
+    </Provider>
+  );
+}

--- a/src/app/create-store.js
+++ b/src/app/create-store.js
@@ -1,0 +1,13 @@
+import { createAppStore } from 'src/store';
+import { reducerMap as applicationReducerMap } from 'src/application';
+import { routerReducer } from 'react-router-redux';
+
+export default function createStore() {
+  return createAppStore(
+    Object.assign(
+      { },
+      applicationReducerMap,
+      { routing: routerReducer }
+    )
+  );
+}

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,0 +1,1 @@
+export { default as ConnectedApp } from './ConnectedApp.js';

--- a/src/app/routes.js
+++ b/src/app/routes.js
@@ -3,12 +3,14 @@ import { route as applicationRoute } from 'src/application';
 import { route as applicationListingRoute } from 'src/application-listing';
 import App from './App';
 
-export default {
-  path: '/',
-  component: App,
-  indexRoute: dashboardRoute,
-  childRoutes: [
-    applicationRoute,
-    applicationListingRoute,
-  ],
+export default function createRoutes(store) {
+  return {
+    path: '/',
+    component: App,
+    indexRoute: dashboardRoute(store),
+    childRoutes: [
+      applicationRoute(store),
+      applicationListingRoute(store),
+    ],
+  };
 }

--- a/src/application-listing/route.js
+++ b/src/application-listing/route.js
@@ -1,6 +1,8 @@
 import ApplicationListing from './ApplicationListing';
 
-export default {
-  component: ApplicationListing,
-  path: 'applications'
+export default function createRoute(store) {
+  return {
+    component: ApplicationListing,
+    path: 'applications',
+  };
 }

--- a/src/application/Application.js
+++ b/src/application/Application.js
@@ -1,5 +1,12 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
-export default function ApplicationListing() {
-  return <div>Application</div>;
+function Application({ id, firstName, lastName }) {
+  return <div>Application {id}: {firstName} {lastName} </div>;
 }
+
+function mapStateToProps({ application }) {
+  return application;
+}
+
+export default connect(mapStateToProps)(Application);

--- a/src/application/index.js
+++ b/src/application/index.js
@@ -1,1 +1,2 @@
 export { default as route } from './route';
+export { reducerMap } from './reducer';

--- a/src/application/reducer.js
+++ b/src/application/reducer.js
@@ -1,0 +1,29 @@
+import { combineReducersByAction } from 'src/store';
+
+const BASE_NAME = 'application';
+const ACTION_FETCH_APPLCATION = `${BASE_NAME}/FETCH_APPLICATION`;
+
+const initialState = { };
+
+// Action Creators
+
+export function fetchApplication(id) {
+  return {
+    type: ACTION_FETCH_APPLCATION,
+    id,
+  };
+}
+
+// Reducers
+
+const reducers = {
+  [ACTION_FETCH_APPLCATION]: (state, { id }) => Object.assign({ }, state, {
+    id,
+    firstName: 'Kared',
+    lastName: 'Jhan',
+  }),
+}
+
+export const reducerMap = {
+  [BASE_NAME]: combineReducersByAction(reducers, initialState),
+};

--- a/src/application/route.js
+++ b/src/application/route.js
@@ -1,6 +1,13 @@
 import Application from './Application';
+import { fetchApplication } from './reducer';
 
-export default {
-  component: Application,
-  path: 'applications/:id'
+export default function createRoute(store) {
+  return {
+    component: Application,
+    path: 'applications/:id',
+    onEnter(nextState, replace, callback) {
+      store.dispatch(fetchApplication(nextState.params.id));
+      callback();
+    },
+  }
 }

--- a/src/dashboard/route.js
+++ b/src/dashboard/route.js
@@ -1,5 +1,7 @@
 import Dashboard from './Dashboard';
 
-export default {
-  component: Dashboard,
-}
+export default function createRoute(store) {
+  return {
+    component: Dashboard,
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Router, browserHistory } from 'react-router';
-import routes from 'src/app/routes';
+
+import { ConnectedApp } from 'src/app';
 
 ReactDOM.render(
-  <Router routes={routes} history={browserHistory} />,
+  <ConnectedApp />,
   document.getElementById('root')
 );

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,26 @@
+import { createStore, compose, combineReducers, applyMiddleware } from 'redux';
+import { composeWithDevTools } from 'redux-devtools-extension';
+
+export function createAppStore(reducerMap) {
+  return createStore(
+    combineReducers(reducerMap),
+    composeWithDevTools(
+      applyMiddleware()
+    )
+  );
+}
+
+/**
+ * Takes a map of action types to reducers, and returns a composite reducer.
+ * When it takes in an action, it will pick the corresponding reducer based on
+ * the action's type.
+ */
+export function combineReducersByAction(reducerMap, initialState) {
+  return (state = initialState, action) => {
+    if (action.type in reducerMap) {
+      return reducerMap[action.type](state, action);
+    }
+
+    return state;
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4314,6 +4314,10 @@ react-router:
     loose-envify "^1.2.0"
     warning "^3.0.0"
 
+react-router-redux:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.7.tgz#9b1fde4e70106c50f47214e12bdd888cfb96e2a6"
+
 react-scripts@0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-0.7.0.tgz#e499ebaf8bb077f7045770eaef1df5cfe308e3e0"
@@ -4502,6 +4506,10 @@ redux:
     lodash-es "^4.2.1"
     loose-envify "^1.1.0"
     symbol-observable "^1.0.2"
+
+redux-devtools-extension:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-1.0.0.tgz#f8bf7a2a093b648054a3814d6d120ad8bc8beaa9"
 
 redux-observable:
   version "0.12.2"


### PR DESCRIPTION
Alright, here's the clincher.

This PR adds [Redux](http://redux.js.org/) as a way of managing state. The gist is that this puts all application in a store, and components subscribe to that store for updates. Components can also dispatch actions to that store which essentially results in a pure function that mutates the store.

This presents us with a number of benefits:
- Our state/logic is completely decoupled from our presentation
- The app behaves far more predictably
- Async stuff (like API calls) will be easier to reason/deal with when they're around
- Our state is one serialisable object, meaning we can do some mean as debugging/time travel with [Redux Developer Tools](https://github.com/zalmoxisus/redux-devtools-extension) (support is in this PR, too)
![image](https://cloud.githubusercontent.com/assets/3238878/20644122/17b6dd5e-b422-11e6-8687-c19e4dd8a1cc.png)
- And some more stuff...

We'll mostly be doing API calls and pushing that into state.

So @jaredkhan, am I talking madness?

