### PR TITLE
Remove old application when fetching new one

### DIFF
--- a/src/application/reducer.js
+++ b/src/application/reducer.js
@@ -74,6 +74,10 @@ const reducers = {
     ...state,
     application,
   }),
+  [ACTION_FETCH_APPLICATION]: (state) => ({
+    ...state,
+    application: null
+  }),
   [ACTION_SET_CRITERIA]: (state, { criteria }) => ({ ...state, criteria }),
 }
 


### PR DESCRIPTION
Old applications were sticking around when we were fetching a new one, which made the UI a little bit deceiving. This fixes that.

@jaredkhan could you review?