### PR TITLE
Add detailed applicant breakdown to dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-router-redux": "^4.0.7",
     "react-scripts": "0.7.0",
     "reactstrap": "^3.9.1",
+    "recharts": "^0.20.1",
     "recompose": "^0.21.0",
     "redux": "^3.6.0",
     "redux-devtools-extension": "^1.0.0",

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -1,13 +1,29 @@
 import React from 'react';
 import { Link } from 'react-router';
 import { Container, Jumbotron, Row, Col, Progress, Button } from 'reactstrap';
+import { PieChart, Pie, ResponsiveContainer, Tooltip, Legend } from 'recharts';
 import './dashboard.css';
 
 function correctPlural(amount, singular = '', plural = 's') {
   return (amount === 1) ? singular : plural;
 }
 
-export default function Dashboard({ signups, applications, reviews, userReviews, userGoal, leaderboard, leaderboardPosition }) {
+function statsToChartData({ applications, reviewed, rsvpedNo, ticketed, turnedDown, invited }) {
+  const invitedData = invited - rsvpedNo - ticketed;
+  const reviewedData = reviewed - invited - turnedDown;
+  const unreviewed = applications - reviewed;
+
+  return [
+    { name: 'Unreviewed', value: unreviewed, fill: '#818a91' }, 
+    { name: 'Reviewed', value: reviewedData, fill: '#0275d8' },
+    { name: 'Invited', value: invitedData, fill: '#5bc0de' },
+    { name: 'Turned Down', value: turnedDown, fill: '#f0ad4e' },
+    { name: 'RSVP No', value: rsvpedNo, fill: '#d9534f' },
+    { name: 'Ticketed', value: ticketed, fill: '#5cb85c' },
+  ];
+}
+
+export default function Dashboard({ signups, applications, reviews, userReviews, userGoal, leaderboard, leaderboardPosition, ticketed, turnedDown, invited, rsvpedNo }) {
   return (
     <Container>
       <Jumbotron>
@@ -19,10 +35,21 @@ export default function Dashboard({ signups, applications, reviews, userReviews,
       </Jumbotron>
       <Row>
         <Col md="6">
-          Group target ({reviews}/{applications}):
-          <Progress value={reviews} max={applications} color="success"/>
-          Personal target ({userReviews}/{userGoal}):
+          <h3>Your target <small>({userReviews}/{userGoal})</small></h3>
           <Progress value={userReviews} max={userGoal} color="warning"/>
+          <h3>Applicant Breakdown</h3>
+            <ResponsiveContainer height={400}>
+            <PieChart width={100} height={100}>
+              <Pie
+                cx="50%"
+                cy="50%"
+                outerRadius={100}
+                fill="#8884d8"
+                data={statsToChartData({ applications, reviewed: reviews, rsvpedNo, ticketed, turnedDown, invited })}/>
+              <Tooltip/>
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
         </Col>
         <Col md="6">
           Leaderboard:

--- a/src/dashboard/DashboardPage.js
+++ b/src/dashboard/DashboardPage.js
@@ -30,6 +30,11 @@ export default connect(mapStateToProps)(componentFromStream(props$ =>
         userReviews={userStats.applicationsReviewedCount}
         userGoal={userStats.applicationsReviewedGoal}
         leaderboard={globalStats.leaderboard}
-        leaderboardPosition={userStats.leaderboardPosition} />
+        leaderboardPosition={userStats.leaderboardPosition} 
+        rsvpedNo={globalStats.rsvpNoCount}
+        ticketed={globalStats.ticketCount}
+        turnedDown={globalStats.rejectionsCount}
+        invited={globalStats.invitationsCount}
+        />
     ).startWith(<p>Loading...</p>)
 ));

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -8,3 +8,7 @@
 	width: 3em;
 	text-align: right;
 }
+
+.progress {
+	overflow: hidden;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,7 +1169,7 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@^2.2.3, classnames@2.x:
+classnames@^2.2.3, classnames@^2.2.5, classnames@2.x:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -1395,7 +1395,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0:
+core-js@^2.4.0, core-js@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
@@ -1545,6 +1545,60 @@ d@^0.1.1, d@~0.1.1:
   resolved "https://registry.yarnpkg.com/d/-/d-0.1.1.tgz#da184c535d18d8ee7ba2aa229b914009fae11309"
   dependencies:
     es5-ext "~0.10.2"
+
+d3-array@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.0.2.tgz#174237bf356a852fadd6af87743d928631de7655"
+
+d3-collection@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.2.tgz#df5acb5400443e9eabe9c1379896c67e52426b39"
+
+d3-color@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.0.2.tgz#83cb4b3a9474e40795f009d97e97a15649830bbc"
+
+d3-format@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.0.2.tgz#138618320b4bbeb43b5c0ff30519079fbbd7375e"
+
+d3-interpolate@1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.2.tgz#b52e6927a04fe1fe2a4cffc139e5389ed3e5e790"
+  dependencies:
+    d3-color "1"
+
+d3-path@1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.3.tgz#60103d0dea9a6cd6ca58de86c6d56724002d3fde"
+
+d3-scale@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.4.tgz#50e28bf6a193b706745528515ed9b3d44205a033"
+  dependencies:
+    d3-array "1"
+    d3-collection "1"
+    d3-color "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-shape@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.0.4.tgz#145ee100ccbec42f8e3f1996cd05c786f79fe1c6"
+  dependencies:
+    d3-path "1"
+
+d3-time-format@2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.0.3.tgz#3241569b74ddc9c42e0689c0e8a903579fd6280a"
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.4.tgz#2ceba09a76b7450c992a1ded4e10fc6195e69649"
 
 damerau-levenshtein@^1.0.0:
   version "1.0.3"
@@ -3421,6 +3475,10 @@ lodash@^4.0.0, lodash@^4.15.0, lodash@^4.16.2, lodash@^4.16.4, lodash@^4.2.0, lo
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
+lodash@^4.17.2:
+  version "4.17.3"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.3.tgz#557ed7d2a9438cac5fd5a43043ca60cb455e01f7"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -3925,6 +3983,10 @@ pbkdf2-compat@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz#b6e0c8fa99494d94e0511575802a59a5c142f288"
 
+performance-now@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -4329,6 +4391,12 @@ querystringify@0.0.x:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-0.0.4.tgz#0cf7f84f9463ff0ae51c4c4b142d95be37724d9c"
 
+raf@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.3.0.tgz#93845eeffc773f8129039f677f80a36044eee2c3"
+  dependencies:
+    performance-now "~0.2.0"
+
 randomatic@^1.1.3:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.5.tgz#5e9ef5f2d573c67bd2b8124ae90b5156e457840b"
@@ -4373,7 +4441,7 @@ react-addons-css-transition-group:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/react-addons-css-transition-group/-/react-addons-css-transition-group-15.4.1.tgz#60b133fac5116e4009e56ab0674dc2ddcc1a18f6"
 
-react-addons-transition-group:
+react-addons-transition-group, "react-addons-transition-group@^0.14.0 || ^15.0.0":
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/react-addons-transition-group/-/react-addons-transition-group-15.4.1.tgz#27d92717089c5e2db202e654a85b76a41b703acc"
 
@@ -4412,6 +4480,10 @@ react-redux:
     invariant "^2.0.0"
     lodash "^4.2.0"
     loose-envify "^1.1.0"
+
+react-resize-detector@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-0.3.3.tgz#ca07443072324843586666d9443a6356da7c0501"
 
 react-router:
   version "3.0.0"
@@ -4477,6 +4549,14 @@ react-scripts@0.7.0:
     whatwg-fetch "1.0.0"
   optionalDependencies:
     fsevents "1.0.14"
+
+react-smooth@^0.1.15:
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-0.1.17.tgz#0810990fdcbb5a5ceaf1fc4ebcb00f255f8e8935"
+  dependencies:
+    lodash "^4.16.4"
+    raf "^3.2.0"
+    react-addons-transition-group "^0.14.0 || ^15.0.0"
 
 react@^15.4.1:
   version "15.4.1"
@@ -4581,6 +4661,24 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
+recharts-scale@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/recharts-scale/-/recharts-scale-0.2.1.tgz#378f543ed17c3245e4d9afb10aaf6298240d2fcb"
+
+recharts@^0.20.1:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-0.20.1.tgz#5f15fbfc9e9245f7aa6291256b137c6630a11682"
+  dependencies:
+    classnames "^2.2.5"
+    core-js "^2.4.1"
+    d3-scale "^1.0.4"
+    d3-shape "^1.0.4"
+    lodash "^4.17.2"
+    react-resize-detector "^0.3.3"
+    react-smooth "^0.1.15"
+    recharts-scale "^0.2.1"
+    reduce-css-calc "^1.3.0"
+
 recompose:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.21.0.tgz#91d50059a04439bba4c3a7b9cd4aef4755a9af19"
@@ -4602,7 +4700,7 @@ redeyed@~1.0.0:
   dependencies:
     esprima "~3.0.0"
 
-reduce-css-calc@^1.2.6:
+reduce-css-calc@^1.2.6, reduce-css-calc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
   dependencies:


### PR DESCRIPTION
This makes our dashboard stats info more useful as we step into invitation season. There are tooltips on the graph but you can't see them in the screenshot

![image](https://cloud.githubusercontent.com/assets/3238878/21575529/6dfe167a-cf73-11e6-8a75-fdb21e8aae96.png)

@jaredkhan could you review?