### PR TITLE
Improve applicant breakdown

### DIFF
--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -8,52 +8,106 @@ function correctPlural(amount, singular = '', plural = 's') {
   return (amount === 1) ? singular : plural;
 }
 
-function statsToChartData({ applications, reviewed, rsvpedNo, ticketed, turnedDown, invited }) {
-  const invitedData = invited - rsvpedNo - ticketed;
-  const reviewedData = reviewed - invited - turnedDown;
-  const unreviewed = applications - reviewed;
-
-  return [
-    { name: 'Unreviewed', value: unreviewed, fill: '#818a91' }, 
-    { name: 'Reviewed', value: reviewedData, fill: '#0275d8' },
-    { name: 'Invited', value: invitedData, fill: '#5bc0de' },
-    { name: 'Turned Down', value: turnedDown, fill: '#f0ad4e' },
-    { name: 'RSVP No', value: rsvpedNo, fill: '#d9534f' },
-    { name: 'Ticketed', value: ticketed, fill: '#5cb85c' },
-  ];
+function DashboardJumbotron({ signups, applications, leaderboardPosition }) {
+  return (
+    <Jumbotron>
+      <h3>{signups} sign up{correctPlural(signups)}</h3>
+      <h1>{applications} Application{correctPlural(applications)}</h1>
+      <p>{leaderboardPosition !== null ? "You are the #" + leaderboardPosition + " reviewer, keep at it!" : "We couldn't work out your leaderboard position, sorry!"}</p>
+      <Button tag={Link} to='/applications/next' color="primary">Start Reviewing</Button>{' '}
+      <Button tag={Link} to='/applications' size="large" color="success">See all Applications</Button>
+    </Jumbotron>
+  );
 }
 
-export default function Dashboard({ signups, applications, reviews, userReviews, userGoal, leaderboard, leaderboardPosition, ticketed, turnedDown, invited, rsvpedNo }) {
+function ApplicantBreakdown({ applicationCount, reviewedCount, rsvpedNoCount, ticketedCount, turnedDownCount, invitedCount, expiredCount }) {
+  return (
+    <div>
+      <h3>Applicant Breakdown</h3>
+      <ResponsiveContainer height={400}>
+        <PieChart width={100} height={100}>
+          <Pie
+            cx="50%"
+            cy="45%"
+            innerRadius={80}
+            outerRadius={100}
+            fill="#8884d8"
+            data={[
+              { name: 'Reviewed', value: reviewedCount, fill: '#0275d8' },
+              { name: 'Awaiting Review', value: applicationCount - reviewedCount, fill: '#aaa' },
+            ]} />
+          <Pie
+            cx="50%"
+            cy="45%"
+            innerRadius={55}
+            outerRadius={75}
+            fill="#8884d8"
+            data={[
+              { name: 'Invited', value: invitedCount, fill: '#5bc0de' },
+              { name: 'Turned Down', value: turnedDownCount, fill: '#f0ad4e' },
+              { name: 'Awaiting Response', value: applicationCount - invitedCount - turnedDownCount, fill: '#bbb' },
+            ]} />
+          <Pie
+            cx="50%"
+            cy="45%"
+            outerRadius={50}
+            endAngle={invitedCount / applicationCount * 360}
+            fill="#8884d8"
+            data={[
+              { name: 'RSVP No', value: rsvpedNoCount, fill: '#d9534f' },
+              { name: 'Expired', value: expiredCount, fill: '#333' },
+              { name: 'Ticketed', value: ticketedCount, fill: '#5cb85c' },
+              { name: 'Awaiting RSVP', value: invitedCount - rsvpedNoCount - expiredCount - ticketedCount, fill: '#ccc' },
+            ]} />
+          <Tooltip/>
+          <Legend/>
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function LeaderboardItem({ name, count }) {
+  return (
+    <li>
+      <span className="leaderboard-name">{name}</span>  &ndash; <span className="leaderboard-score">{count}</span>
+    </li>
+  );
+}
+
+function Leaderboard({ leaderboard }) {
+  return (
+    <div>
+      <h3>Leaderboard:</h3>
+      <ol>
+        {leaderboard.map(reviewer => <LeaderboardItem key={reviewer.id} {...reviewer} />)}
+      </ol>
+    </div>
+  );
+}
+
+export default function Dashboard({ globalStats, userStats }) {
   return (
     <Container>
-      <Jumbotron>
-        <h3>{signups} sign up{correctPlural(signups)}</h3>
-        <h1>{applications} Application{correctPlural(applications)}</h1>
-        <p>{leaderboardPosition !== null ? "You are the #" + leaderboardPosition + " reviewer, keep at it!" : "We couldn't work out your leaderboard position, sorry!"}</p>
-        <Button tag={Link} to='/applications/next' color="primary">Start Reviewing</Button>{' '}
-        <Button tag={Link} to='/applications' size="large" color="success">See all Applications</Button>
-      </Jumbotron>
+      <DashboardJumbotron
+        signups={globalStats.hackerCount}
+        applications={globalStats.hackerApplicationCount}
+        leaderboardPosition={userStats.leaderboardPosition} />
       <Row>
         <Col md="6">
-          <h3>Your target <small>({userReviews}/{userGoal})</small></h3>
-          <Progress value={userReviews} max={userGoal} color="warning"/>
-          <h3>Applicant Breakdown</h3>
-            <ResponsiveContainer height={400}>
-            <PieChart width={100} height={100}>
-              <Pie
-                cx="50%"
-                cy="50%"
-                outerRadius={100}
-                fill="#8884d8"
-                data={statsToChartData({ applications, reviewed: reviews, rsvpedNo, ticketed, turnedDown, invited })}/>
-              <Tooltip/>
-              <Legend />
-            </PieChart>
-          </ResponsiveContainer>
+          <h3>Your target <small>({userStats.applicationsReviewedCount}/{userStats.applicationsReviewedGoal})</small></h3>
+          <Progress value={userStats.applicationsReviewedCount} max={userStats.applicationsReviewedGoal} color="warning" />
+          <ApplicantBreakdown
+            applicationCount={globalStats.hackerApplicationCount}
+            reviewedCount={globalStats.applicationsReviewedCount}
+            rsvpedNoCount={globalStats.rsvpNoCount}
+            ticketedCount={globalStats.ticketCount}
+            turnedDownCount={globalStats.rejectionsCount}
+            invitedCount={globalStats.invitationsCount}
+            expiredCount={globalStats.expiredCount} />
         </Col>
         <Col md="6">
-          Leaderboard:
-          <ol>{leaderboard.map(reviewer => <li key={"leaderboard-entry-" + reviewer.id}><span className="leaderboard-name">{reviewer.name}</span>  &ndash; <span className="leaderboard-score">{reviewer.count}</span></li>)}</ol>
+          <Leaderboard leaderboard={globalStats.leaderboard} />
         </Col>
       </Row>
     </Container>

--- a/src/dashboard/DashboardPage.js
+++ b/src/dashboard/DashboardPage.js
@@ -24,17 +24,7 @@ export default connect(mapStateToProps)(componentFromStream(props$ =>
     }))
     .map(({ globalStats, userStats }) => 
       <Dashboard 
-        signups={globalStats.hackerCount}
-        applications={globalStats.hackerApplicationCount}
-        reviews={globalStats.applicationsReviewedCount}
-        userReviews={userStats.applicationsReviewedCount}
-        userGoal={userStats.applicationsReviewedGoal}
-        leaderboard={globalStats.leaderboard}
-        leaderboardPosition={userStats.leaderboardPosition} 
-        rsvpedNo={globalStats.rsvpNoCount}
-        ticketed={globalStats.ticketCount}
-        turnedDown={globalStats.rejectionsCount}
-        invited={globalStats.invitationsCount}
-        />
+        globalStats={globalStats}
+        userStats={userStats} />
     ).startWith(<p>Loading...</p>)
 ));


### PR DESCRIPTION
This improves the applicant breakdown by removing the inferred values and giving all stats as a proportion of the entire set of applications. This is achieved with pie chart layers

![image](https://cloud.githubusercontent.com/assets/3238878/21749402/e9a58d5e-d602-11e6-8dbb-7d79dfa5c52d.png)

@jaredkhan could you review?
