### PR TITLE
Update skip functionality to call new API endpoint

### DIFF
--- a/src/application/Application.js
+++ b/src/application/Application.js
@@ -82,8 +82,7 @@ export default class Application extends React.Component {
             <Button
               color="warning"
               className="footer-button"
-              tag={Link}
-              to='/applications/next'>Skip</Button>
+              onClick={this.props.onSkip}>Skip</Button>
 
             <Button
               color="success"

--- a/src/application/ApplicationPage.js
+++ b/src/application/ApplicationPage.js
@@ -4,7 +4,7 @@ import { componentFromStream } from 'recompose';
 import shallowEquals from 'shallow-equals';
 import Rx from 'rxjs';
 
-import { submitReview } from './reducer';
+import { skipReview, submitReview } from './reducer';
 import Application from './Application';
 import { getApplicationWithReview } from './api';
 
@@ -15,6 +15,7 @@ const mapStateToProps = ({ application, user: { authToken, userInfo } }) => ({
 });
 
 const mapDispatchToProps = {
+  onSkip: skipReview,
   onSubmit: submitReview,
 };
 
@@ -27,7 +28,7 @@ function getApplicationFromProps(props$) {
     );
 }
 
-function renderApplication(application, { criteria, onSubmit, adminId }) {
+function renderApplication(application, { criteria, onSkip, onSubmit, adminId }) {
   if ((!application) || (!criteria)) {
     return <p>Loading...</p>;
   }
@@ -45,6 +46,7 @@ function renderApplication(application, { criteria, onSubmit, adminId }) {
     criteria={criteria}
     criteriaScores={criteriaScores}
     key={application.id}
+    onSkip={_ => onSkip(adminId, application.id)}
     onSubmit={(scores) => onSubmit(adminId, application.id, scores)} />;
 }
 

--- a/src/application/api.js
+++ b/src/application/api.js
@@ -31,3 +31,10 @@ export function submitReview(token, adminId, applicationId, scores) {
     }),
   });
 }
+
+export function skipReview(token, adminId, applicationId) {
+  return makeApiCall(token, `admins/${adminId}/skip-review/${applicationId}`, {
+    method: 'POST',
+    body: ''
+  });
+}

--- a/src/application/reducer.js
+++ b/src/application/reducer.js
@@ -6,6 +6,7 @@ import { ACTION_SIGN_IN_SUCCEEDED } from 'src/user';
 import * as api from './api';
 
 const BASE_NAME = 'application';
+const ACTION_SKIP_REVIEW = `${BASE_NAME}/SKIP_REVIEW`;
 const ACTION_SUBMIT_REVIEW = `${BASE_NAME}/SUBMIT_REVIEW`;
 const ACTION_SET_CRITERIA = `${BASE_NAME}/SET_CRITERIA`;
 
@@ -14,6 +15,14 @@ const initialState = {
 };
 
 // Action Creators
+
+export function skipReview(adminId, applicationId) {
+  return {
+    type: ACTION_SKIP_REVIEW,
+    adminId,
+    applicationId
+  }
+}
 
 export function submitReview(adminId, applicationId, scores) {
   return {
@@ -41,6 +50,11 @@ export function epic(action$, store) {
     action$.ofType(ACTION_SUBMIT_REVIEW)
       .switchMap(({ scores, adminId, applicationId }) =>
         api.submitReview(store.getState().user.authToken, adminId, applicationId, scores)
+      )
+      .map(() => push('/applications/next')),
+    action$.ofType(ACTION_SKIP_REVIEW)
+      .switchMap(({ adminId, applicationId }) =>
+        api.skipReview(store.getState().user.authToken, adminId, applicationId)
       )
       .map(() => push('/applications/next'))
   );


### PR DESCRIPTION
The skip button now calls the `skip-review` API endpoint so the admin is not allocated the application again for reviewing.